### PR TITLE
Fixed issue #58 more

### DIFF
--- a/tkintertable/Tables.py
+++ b/tkintertable/Tables.py
@@ -2235,7 +2235,7 @@ class TableCanvas(Canvas):
             model.importDict(importer.data)
         else:
             model = TableModel()
-            model.importCSV(filename)
+            model.importCSV(filename, sep=sep)
         self.updateModel(model)
         return
 


### PR DESCRIPTION
As far as I see, the previous fix of the issue #58 only adds the `sep` parameter to the `Tables.importCSV` function, which prevents the `unexpected keyword argument 'sep'` error, but the `sep` parameter is still not passed to the `TableModels.importCSV` function, so the default separator is used anyway.